### PR TITLE
Fixed Ubuntu 22.04 gcc 9.5 compile errors  and some warnings

### DIFF
--- a/src/Client_connection.cpp
+++ b/src/Client_connection.cpp
@@ -1295,7 +1295,7 @@ int Client_connection::get_pipe_count(thread_data* local_buf, char* event_data,i
         return 0;
     }
 
-    if( pMarker > 0 && end_pMarker > 0)
+    if( (long)pMarker > 0 && (long)end_pMarker > 0)
     {
         *end_pMarker = 0;
         send_pipe_count(local_buf, pipe_name, pMarker);

--- a/src/CometQL.h
+++ b/src/CometQL.h
@@ -122,11 +122,11 @@ public:
 
 
     bool isMatch(){
-
+       return false;
     }
 
     MySqlResulValue getValue(){
-
+	return MySqlResulValue();
     }
 
     sqlExpression operator = (sqlExpression exp){

--- a/src/MySql_connection.cpp
+++ b/src/MySql_connection.cpp
@@ -1947,7 +1947,7 @@ int MySql_connection::sql_select_from_revoked_tokens(thread_data* local_buf, uns
         }
 
         char* token = local_buf->qInfo.where.whereExprValue[idExprPos][i].Start(local_buf->qInfo);
-        if(token <= 0)
+        if((long)token <= 0)
         {
             continue;
         }
@@ -2095,7 +2095,7 @@ int MySql_connection::sql_delete_from_revoked_tokens(thread_data* local_buf, uns
         }
 
         char* token = local_buf->qInfo.where.whereExprValue[idExprPos][i].Start(local_buf->qInfo);
-        if(token <= 0)
+        if((long)token <= 0)
         {
             continue;
         }

--- a/src/dbLink.h
+++ b/src/dbLink.h
@@ -9,6 +9,7 @@
 #ifndef DBLINK_H
 #define	DBLINK_H
 
+#define my_bool bool
 
 class stmMapper;
 class dbLink;
@@ -55,7 +56,7 @@ protected:
      */
     bool free();
     
-    bool virtual prepare(dbLink *mysql){}
+    bool virtual prepare(dbLink *mysql){ return false; }
     
 public:
     MYSQL_STMT *getSTMT()

--- a/src/intervalLoop.h
+++ b/src/intervalLoop.h
@@ -7,6 +7,7 @@
 
 #include <list>     // подключаем заголовок списка 
 #include <functional>
+#include <pthread.h>
 
 class thread_data;
 class intervalLoop;


### PR DESCRIPTION
fixed:
- warning: no return statement in function returning non-void [-Wreturn-type]
- error: ordered comparison of pointer with integer zero (‘char*’ and ‘int’)
- error: my_bool undefined 
- error: pthread_* - undefined

